### PR TITLE
Include `-m` flag in `docker run` call to limit memory per container

### DIFF
--- a/supervisor/src/main.go
+++ b/supervisor/src/main.go
@@ -349,6 +349,7 @@ func (sv *supervisor) reload() error {
 		"-p", fmt.Sprintf("127.0.0.1:%d:6119", port),
 		"-e", "FATHOM_SITE_ID",
 		"-e", "RIJU_DEPLOY_CONFIG",
+		"-m", "200m",
 		"--label", fmt.Sprintf("riju.deploy-config-hash=%s", deployCfgHash),
 		"--name", name,
 		"--restart", "unless-stopped",


### PR DESCRIPTION
As per Docker run documentation (https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory), the `-m` flag must be set in order for `--oom-kill-disable` to have the intended effect. Otherwise, an exhaustion of memory in the container will put pressure on the host's processes. This commit sets the max memory to 200MB assuming the t3.small instance has 2GB total (just a guess, probably not the optimal number).

Here is the relevant section in the documentation:
"By default, if an out-of-memory (OOM) error occurs, the kernel kills processes in a container. To change this behavior, use the --oom-kill-disable option. Only disable the OOM killer on containers where you have also set the -m/--memory option. If the -m flag is not set, the host can run out of memory and the kernel may need to kill the host system’s processes to free memory."

This could limit the impact of tampering on the service as was shown in #83.

I have not tested out this commit due to inability to build it myself, but I don't see any conflicts or issues in plain sight.