### PR TITLE
add jbang

### DIFF
--- a/langs/jbang.yaml
+++ b/langs/jbang.yaml
@@ -1,6 +1,4 @@
 id: "jbang"
-aliases:
-  - "javac"
 name: "JBang"
 monacoLang: java
 

--- a/langs/jbang.yaml
+++ b/langs/jbang.yaml
@@ -1,0 +1,159 @@
+id: "jbang"
+aliases:
+  - "javac"
+name: "JBang"
+monacoLang: java
+
+install:
+  apt:
+    - default-jdk
+    - clang-format
+  manual: |
+    install -d "${pkg}/opt/jdt"
+
+    wget https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
+    tar -xf jdt-language-server-latest.tar.gz -C "${pkg}/opt/jdt"
+
+
+
+
+main: "Main.java"
+template: |
+  public class Main {
+      public static void main(String[] args) {
+          System.out.println("Hello, world!");
+      }
+  }
+
+run: |
+    curl -Ls https://sh.jbang.dev | bash -s - Main.java
+
+format:
+  run: |
+    clang-format --style="{BasedOnStyle: llvm, IndentWidth: 4}" --assume-filename=Format.java
+  input: |
+    public class Main
+    {
+        public static void main(String[] args)
+        {
+            System.out.println("Hello, world!");
+        }
+    }
+
+lsp:
+  setup: |
+    rm -rf jdt && cp -RT /opt/jdt/config_linux jdt
+  start: |
+    java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.level=ALL -noverify -Xmx1G -jar /opt/jdt/plugins/org.eclipse.equinox.launcher_*.jar -configuration "$PWD/jdt" -data "$PWD" --add-modules=ALL-SYSTEM --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
+  init:
+    bundles:
+      - /opt/jdt/bundles/com.microsoft.java.test.plugin-0.19.0.jar
+      - /opt/jdt/bundles/com.microsoft.jdtls.ext.core-0.5.1.jar
+      - /opt/jdt/bundles/dg.jdt.ls.decompiler.cfr-0.0.2-201802221740.jar
+      - /opt/jdt/bundles/dg.jdt.ls.decompiler.common-0.0.2-201802221740.jar
+      - /opt/jdt/bundles/dg.jdt.ls.decompiler.fernflower-0.0.2-201802221740.jar
+      - /opt/jdt/bundles/dg.jdt.ls.decompiler.procyon-0.0.2-201802221740.jar
+      - /opt/jdt/bundles/io.projectreactor.reactor-core.jar
+      - /opt/jdt/bundles/java.debug.plugin.jar
+      - /opt/jdt/bundles/jdt-ls-commons.jar
+      - /opt/jdt/bundles/jdt-ls-extension.jar
+      - /opt/jdt/bundles/org.reactivestreams.reactive-streams.jar
+    extendedClientCapabilities:
+      advancedExtractRefactoringSupport: true
+      advancedGenerateAccessorsSupport: true
+      advancedOrganizeImportsSupport: true
+      classFileContentsSupport: true
+      generateConstructorsPromptSupport: true
+      generateToStringPromptSupport: true
+      hashCodeEqualsPromptSupport: true
+      moveRefactoringSupport: true
+      overrideMethodsPromptSupport: true
+      progressReportProvider: true
+    settings:
+      java:
+        autobuild:
+          enabled: true
+        codeGeneration:
+          generateComments: false
+          hashCodeEquals:
+            useInstanceof: false
+            useJava7Objects: false
+          toString:
+            codeStyle: STRING_CONCATENATION
+            limitElements: 0
+            listArrayContents: true
+            skipNullValues: false
+            template: ${object.className} [${member.name()}=${member.value}, ${otherMembers}]
+          useBlocks: false
+        completion:
+          enabled: true
+          favoriteStaticMembers:
+            - org.junit.Assert.*
+            - org.junit.Assume.*
+            - org.junit.jupiter.api.Assertions.*
+            - org.junit.jupiter.api.Assumptions.*
+            - org.junit.jupiter.api.DynamicContainer.*
+            - org.junit.jupiter.api.DynamicTest.*
+            - org.mockito.Mockito.*
+            - org.mockito.ArgumentMatchers.*
+            - org.mockito.Answers.*
+          filteredTypes:
+            - java.awt.*
+            - com.sun.*
+          guessMethodArguments: true
+          importOrder:
+            - java
+            - javax
+            - com
+            - org
+          overwrite: true
+        configuration:
+          checkProjectSettingsExclusions: true
+          updateBuildConfiguration: automatic
+        dependency:
+          packagePresentation: flat
+        errors:
+          incompleteClasspath:
+            severity: warning
+        foldingRange:
+          enabled: true
+        format:
+          comments:
+            enabled: true
+          enabled: true
+          onType:
+            enabled: true
+        implementationsCodeLens:
+          enabled: false
+        import:
+          exclusions:
+            - '**/node_modules/**'
+            - '**/.metadata/**'
+            - '**/archetype-resources/**'
+            - '**/META-INF/maven/**'
+          gradle:
+            enabled: true
+            wrapper:
+              enabled: true
+          maven:
+            enabled: true
+        maven:
+          downloadSources: false
+        maxConcurrentBuilds: 1
+        progressReports:
+          enabled: true
+        referencesCodeLens:
+          enabled: false
+        saveActions:
+          organizeImports: false
+        selection:
+          enabled: true
+        signatureHelp:
+          enabled: true
+        trace:
+          server: "off"
+  code: "TODO"
+  item: "TODO"
+
+skip:
+  - lsp

--- a/langs/jbangjshell.yaml
+++ b/langs/jbangjshell.yaml
@@ -1,5 +1,5 @@
-id: "jbang"
-name: "Java w/JBang"
+id: "jbangjshell"
+name: "JShell"
 monacoLang: java
 
 install:
@@ -19,28 +19,21 @@ install:
     wget https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz
     tar -xf jdt-language-server-latest.tar.gz -C "${pkg}/opt/jdt"
 
-main: "Main.java"
+main: "Main.jsh"
 template: |
-  public class Main {
-      public static void main(String[] args) {
-          System.out.println("Hello, world!");
-      }
-  }
+    System.out.println("Hello, world!");
 
 run: |
-    jbang Main.java
+    jbang Main.jsh
+
+repl: |
+    jbang --interactive Main.jsh
 
 format:
   run: |
     clang-format --style="{BasedOnStyle: llvm, IndentWidth: 4}" --assume-filename=Format.java
   input: |
-    public class Main
-    {
-        public static void main(String[] args)
-        {
-            System.out.println("Hello, world!");
-        }
-    }
+     System.out.println("Hello, world!");
 
 lsp:
   setup: |


### PR DESCRIPTION
This adds a `jbang` language but it would make more sense this was used by `java`
to enable use of dependencies.

i.e. you can run this java code with this:

```java
///usr/bin/env jbang "$0" "$@" ; exit $?
//DEPS com.github.lalyos:jfiglet:0.0.8

import com.github.lalyos.jfiglet.FigletFont;

class hello {

    public static void main(String... args) throws Exception {
        System.out.println(FigletFont.convertOneLine(
               "Hello " + ((args.length>0)?args[0]:"jbang")));  ;;
    }
}
```

Notice the `//DEPS` line that is picked up by jbang to build and run with that dependency.

I did try add install steps under manual but for some reason `java` is not available
within that making it difficult to install jbang using jbang itself.

Is there a way to have `java` available in the `manual` section ?

Otherwise I'll need to add more manual steps to install jbang.