### PR TITLE
Add Java, Clang, llvm, and elinks to bash language environment

### DIFF
--- a/langs/bash.yaml
+++ b/langs/bash.yaml
@@ -27,6 +27,10 @@ info:
 install:
   apt:
     - bash
+    - default-jdk
+    - elinks
+    - clang-9
+    - llvm
   npm:
     - bash-language-server
 


### PR DESCRIPTION
I'm trying to build v86.