### PR TITLE
Fix watchexec release version

### DIFF
--- a/docker/runtime/install.bash
+++ b/docker/runtime/install.bash
@@ -2,8 +2,8 @@
 
 set -euxo pipefail
 
-latest_release() {
-    curl -sSL "https://api.github.com/repos/$1/releases/latest" | jq -r .tag_name
+latest_watchexec_release() {
+    curl -sSL "https://api.github.com/repos/$1/releases" | jq -c -r '[ .[] | select( .tag_name | test("^cli-v") ) ] | first | .tag_name'
 }
 
 mkdir /tmp/riju-work
@@ -72,7 +72,7 @@ apt-get install -y $(sed 's/#.*//' <<< "${packages}")
 
 pip3 install poetry
 
-ver="$(latest_release watchexec/watchexec | sed 's/^cli-v//')"
+ver="$(latest_watchexec_release watchexec/watchexec | sed 's/^cli-v//')"
 wget "https://github.com/watchexec/watchexec/releases/download/cli-v${ver}/watchexec-${ver}-x86_64-unknown-linux-gnu.deb"
 apt-get install -y ./watchexec-*.deb
 

--- a/docker/runtime/install.bash
+++ b/docker/runtime/install.bash
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 latest_watchexec_release() {
-    curl -sSL "https://api.github.com/repos/$1/releases" | jq -c -r '[ .[] | select( .tag_name | test("^cli-v") ) ] | first | .tag_name'
+    curl -sSL "https://api.github.com/repos/$1/releases" | jq -c -r '[.[] | select(.tag_name | test("^cli-v"))] | first | .tag_name'
 }
 
 mkdir /tmp/riju-work


### PR DESCRIPTION
I found a problem related to [watchexec release](https://github.com/watchexec/watchexec/releases).

When getting the latest release, it will get version [Lib v2.0.0-pre.10](https://github.com/watchexec/watchexec/releases/tag/lib-v2.0.0-pre.10) instead of [CLI v1.18.6](https://github.com/watchexec/watchexec/releases/tag/cli-v1.18.6). That will cause an error because Lib v2.0.0 doesn't contain a deb package. This script will fix it by filtering and getting the latest cli-* only.