### PR TITLE
General enhancements to improve responsiveness

### DIFF
--- a/frontend/pages/app.ejs
+++ b/frontend/pages/app.ejs
@@ -2,6 +2,7 @@
 <html lang="en" style="overflow: hidden">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= config.name %> - Riju</title>
     <link
       rel="stylesheet"
@@ -61,8 +62,8 @@
             </span>
           </button>
         </div>
-        <div style="height: 100%">
-          <div id="editor" style="height: 100%; margin: 12px; margin-left: 0"></div>
+        <div id="editor-wrapper">
+          <div id="editor" style="height: 100%; margin-top: 30px; margin-left: 0"></div>
         </div>
       </div>
       <div class="column" id="terminal" style="background: black; padding: 0">

--- a/frontend/pages/index.ejs
+++ b/frontend/pages/index.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Riju</title>
     <link rel="stylesheet" href="/css/index.css" />
     <% if (analyticsTag) { %>

--- a/frontend/styles/app.css
+++ b/frontend/styles/app.css
@@ -5,3 +5,13 @@
 #header .button {
   border-radius: 0;
 }
+
+@media (max-width: 767px) {
+  #editor-wrapper {
+    max-height: 50vh !important;
+  }
+}
+
+#editor-wrapper {
+  height: 100%;
+}


### PR DESCRIPTION
Changelog:

- Added meta tags for viewport to make bulma responsive classes to work
- Added max height for editor in smaller devices to split the screen vertically

I was unable to verify these changes unfortunately. WSL 2 refuses to work on my Windows. If the css changes can be tested and passed through, it can then be merged, but the meta tag I'm very certain can improve the situation with responsiveness. I made the CSS related changes based on browser inspect tab changes :smile: 

A preview of how it looks (or supposed to look) on an emulated mobile device:

![image](https://github.com/radian-software/riju/assets/69810988/6e6001f4-7ae9-4b26-a1b3-5ff30125d846)
